### PR TITLE
Update AUR instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ must be run with sudo priviliges
 
 ## Install `Arch AUR`
 ```
-yay -S netscanner-bin
+paru -S netscanner
 ```
 
 ## Install via Cargo


### PR DESCRIPTION
I created the following AUR package: https://aur.archlinux.org/packages/netscanner

This PR updates README.md to suggest installing that package (builds from source) and also changes `yay` to [`paru`](https://aur.archlinux.org/packages/paru) (which is more modern / written in Rust).
