### PR TITLE
Update Arch Linux instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ sudo chown root:user /home/user/.cargo/bin/netscanner
 sudo chmod u+s /home/user/.cargo/bin/netscanner
 ```
 
-## Install `Arch AUR`
+## Install on Arch Linux
 ```
-paru -S netscanner
+pacman -S netscanner
 ```
 
 ## Install `Cargo`


### PR DESCRIPTION
I moved `netscanner` package to the official repositories: <https://archlinux.org/packages/extra/x86_64/netscanner/> 🥳
