### PR TITLE
Add dependencies that support the loongarch64 architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,9 +834,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libredox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ipnetwork = "0.20.0"
 itertools = "0.12.0"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
-libc = "0.2.148"
+libc = "0.2.155"
 log = "0.4.20"
 mac_oui = { version = "0.4.8", features = ["with-db"] }
 pnet = "0.34.0"


### PR DESCRIPTION
Add dependencies that support the loongarch64 architecture
https://github.com/rust-lang/libc/pull/2765