### PR TITLE
Deb Package Workflow (#29)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,22 +1,37 @@
 name: Rust
 
-on:
-  push:
-    branches: [ "main" ]
+on: 
   pull_request:
     branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always
+  RELEASE_TAG: 0.5.1-1 # This is the version of the package, it should be updated with every release
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+    - name: Create Debian package
+      uses: dominicorsi/cargo-deb-ubuntu@main
+    
+    - name: Upload Netscanner Debian Package (amd64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: netscanner_${{ env.RELEASE_TAG }}_amd64.deb
+        path: netscanner_${{ env.RELEASE_TAG }}_amd64.deb
+    
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+          files: netscanner_${{ env.RELEASE_TAG }}_amd64.deb

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
       run: cargo test --verbose
 
     - name: Create Debian package
-      uses: dominicorsi/cargo-deb-ubuntu@main
+      uses: dominicorsi/cargo-deb-ubuntu@1.0.0
     
     - name: Upload Netscanner Debian Package (amd64)
       uses: actions/upload-artifact@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: 
+on:
   push:
     branches: [ "main" ]
   pull_request:
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --release
     - name: Run tests
       run: cargo test --verbose
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,8 @@
 name: Rust
 
 on: 
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -12,7 +14,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,48 @@ authors = ["Chleba <chlebik@gmail.com>"]
 repository = "https://github.com/Chleba/netscanner"
 homepage = "https://github.com/Chleba/netscanner"
 
+[package.metadata.deb]
+maintainer = "Dominic Orsi <dominic.orsi@gmail.com>"
+depends = "$auto"
+section = "utils"
+priority = "optional"
+changelog = "debian/changelog"
+license-file = ["LICENSE", "4"]
+extended-description = """\
+Terminal Network scanner & diagnostic tool with modern TUI (terminal user interface). \n
+GitHub: https://github.com/Chleba/netscanner"""
+assets = [
+    [
+        "target/release/netscanner",
+        "usr/bin/",
+        "4755",
+    ],
+    [
+        "README.md",
+        "usr/share/doc/netscanner/README",
+        "644",
+    ],
+    [
+        "debian/netscanner.manpage",
+        "usr/share/man/man1/netscanner.1",
+        "644",
+    ],
+]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 better-panic = "0.3.0"
 chrono = "0.4.31"
 cidr = "0.2.2"
-clap = { version = "4.4.5", features = ["derive", "cargo", "wrap_help", "unicode", "string", "unstable-styles"] }
+clap = { version = "4.4.5", features = [
+    "derive",
+    "cargo",
+    "wrap_help",
+    "unicode",
+    "string",
+    "unstable-styles",
+] }
 color-eyre = "0.6.2"
 config = "0.13.3"
 crossterm = { version = "0.27.0", features = ["serde", "event-stream"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Chleba/netscanner"
 
 [package.metadata.deb]
 maintainer = "Dominic Orsi <dominic.orsi@gmail.com>"
-depends = "$auto"
+depends = "iw"
 section = "utils"
 priority = "optional"
 changelog = "debian/changelog"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+netscanner (0.5.1-1) stable; urgency=medium
+
+  * Initial release.
+
+ -- Dominic Orsi <dominic.orsi@gmail.com>  Sun, 23 Jun 2024 17:25:30 -0700

--- a/debian/netscanner.manpage
+++ b/debian/netscanner.manpage
@@ -4,12 +4,26 @@
 .SH NAME
 netscanner \- view and scan connected networks
 .SH SYNOPSIS
-netscanner
+.B netscanner
+[\fIOPTION\fR]...
 .SH DESCRIPTION
-Netscanner is a terminal network scanner & diagnostic tool with modern TUI.
+.B netscanner
+is a terminal network scanner & diagnostic tool with modern TUI.
 .SH OPTIONS
-Netscanner does not take any options.
+.TP
+.BR \-t ", " \-\-tick\-rate " " \fIFLOAT\fR
+Tick rate, i.e. number of ticks per second [default: 1]
+.TP
+.BR \-f ", " \-\-frame\-rate " " \fIFLOAT\fR
+Frame rate, i.e. number of frames per second [default: 10]
+.TP
+.BR \-h ", " \-\-help
+Print help
+.TP
+.BR \-V ", " \-\-version
+Print version
 .SH BUGS
-No known bugs.
+See GitHub issues:
+https://github.com/chleba/netscanner/issues
 .SH AUTHOR
 Dominic Orsi <dominic.orsi@gmail.com>

--- a/debian/netscanner.manpage
+++ b/debian/netscanner.manpage
@@ -1,0 +1,15 @@
+.\" Manpage for netscanner.
+.\" Contact dominic.orsi@gmail.com to correct errors or typos.
+.TH man 1 "22 June 2024" "1.0" "netscanner man page"
+.SH NAME
+netscanner \- view and scan connected networks
+.SH SYNOPSIS
+netscanner
+.SH DESCRIPTION
+Netscanner is a terminal network scanner & diagnostic tool with modern TUI.
+.SH OPTIONS
+Netscanner does not take any options.
+.SH BUGS
+No known bugs.
+.SH AUTHOR
+Dominic Orsi <dominic.orsi@gmail.com>


### PR DESCRIPTION
## About
Adds a GitHub action to create Debian packages for each release and the required files need to conform to Debian guides. Currently complies Debian packages for amd64.

Maintainer will need to update rust.yml release tag variable with each release to ensure Debian packages are uploaded for each release.


## Updates
**rust.yml**: New GitHub workflow to create Debian packages and add to release
**Cargo.toml**: Added [cargo-deb](https://github.com/kornelski/cargo-deb) configuration section
**debian/changelog**: Added changelog in accordance with [Debian 4.4](https://www.debian.org/doc/debian-policy/ch-source.html#s-dpkgchangelog)
**debian/netscanner.manpage**: Added netscanner manpage in accordance with [Debian 12.1](https://www.debian.org/doc/debian-policy/ch-docs.html#manual-pages)

## To-Do's
- Add compilation for aarch64 Debian packages
- RELEASE_TAG in rust.yml is automatically updated with each release.