### PR TITLE
Stop panic on no ports to scan

### DIFF
--- a/src/components/ports.rs
+++ b/src/components/ports.rs
@@ -154,6 +154,10 @@ impl Ports {
     }
 
     fn scan_ports(&mut self, index: usize) {
+        if index >= self.ip_ports.len() {
+            return; // -- index out of bounds
+        }
+
         self.ip_ports[index].state = PortsScanState::Scanning;
 
         let tx = self.action_tx.clone().unwrap();


### PR DESCRIPTION
This PR fixes the issue when you press `s` to scan ports, netscanner crashes if there are no ports.

This is fixed by returning, so nothing happens.