### PR TITLE
Update `http_req` to v0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,12 +1049,14 @@ dependencies = [
 
 [[package]]
 name = "http_req"
-version = "0.11.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0122ab6637149482eb66b57288ac597bc7eb9859cbaa79dee62fa19a350df3d2"
+checksum = "cd6349b559f67d8fc01513c3b67b304644617d617c12cbfcd2803ffed56d1cf2"
 dependencies = [
+ "base64 0.22.1",
  "native-tls",
  "unicase",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscanner"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Network Scanner"
 license = "MIT"
@@ -95,7 +95,7 @@ tui-scrollview = "0.4.0"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 anyhow = "1.0.86"
-http_req = "0.11.1"
+http_req = "0.13.3"
 zip = "2.1.6"
 clap = { version = "4.5.13", features = ["derive"] }
 clap-verbosity-flag = "2.2.1"


### PR DESCRIPTION
Update `http_req` to latest version v0.13.3. This version includes: 
* **New Features**: Added support for Basic and Bearer `Authentication`, allowing for more secure API interactions. Customizable redirect policies are available as well. Default headers now include `User-Agent`.
* **Security & Reliability**: Dependency updates enhance overall security and stability.
* **Breaking changes**: Notable changes include renaming `RequestBuilder` to `RequestMessage` and changes to `Stream`. However, they should not affect `netscanner`.

Full list of changes can be found at [http_req/releases](https://github.com/jayjamesjay/http_req/releases)